### PR TITLE
Allow FFMPEG binary to be specified via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,18 @@ Type: ```Enum ```
 
 Default: ``` Stack ```
 
-
 Choose type of return value
 
 - Stack will be series of peak by picking highest absolute value in given window(sampling rate)
   ![Alt text](/doc/stack.png "Stack")
 - Line will be series of value by the sampling rate
   ![Alt text](/doc/line.png "Line")
+
+### ffmpegPath
+Type: ```String ```
+
+Default: ``` ffmpeg ```
+
+Location of the 'ffmpeg' binary.  Check out the 'ffmpeg-static' package for static binaries.
+
 

--- a/waveform-node.js
+++ b/waveform-node.js
@@ -35,7 +35,7 @@ var getDataFromFFMpeg = function(filepath, options, callback){
 
         // Allow for the ffmpeg path to be specified via options
         try {
-                if (typeof(options.ffmpegPath !== 'undefined') && options.ffmpegPath != null) {
+                if (typeof(options.ffmpegPath) !== 'undefined' && options.ffmpegPath != null) {
                   ffmpegPath = options.ffmpegPath;
                 }
         } catch (ex) {

--- a/waveform-node.js
+++ b/waveform-node.js
@@ -31,10 +31,20 @@ var getDataFromFFMpeg = function(filepath, options, callback){
 	var gotData = false;
 	var samples = [];
 	var channel = 0;
-  
-	// Extract signed 16-bit little endian PCM data with ffmpeg and pipe to
-	// stdout
-	var ffmpeg = spawn('ffmpeg', ['-i',filepath,'-f','s16le', '-acodec','pcm_s16le','-y','pipe:1']);
+        var ffmpegPath = '';
+
+        // Allow for the ffmpeg path to be specified via options
+        try {
+                if (typeof(options.ffmpegPath !== 'undefined') && options.ffmpegPath != null) {
+                  ffmpegPath = options.ffmpegPath;
+                }
+        } catch (ex) {
+          ffmpegPath = 'ffmpeg';
+        }
+
+        // Extract signed 16-bit little endian PCM data with ffmpeg and pipe to
+        // stdout
+        var ffmpeg = spawn(ffmpegPath, ['-i',filepath,'-f','s16le', '-acodec','pcm_s16le','-y','pipe:1']);
 	ffmpeg.stdout.on('data', function(data){
 		gotData = true;
 		var value;


### PR DESCRIPTION
This pull request allows the ffmpeg binary to be specified via the options for those who use static ffmpeg binaries on their system or have it installed in a location not accessible via the path.