### PR TITLE
Fix duration to include partial seconds

### DIFF
--- a/waveform-node.js
+++ b/waveform-node.js
@@ -91,6 +91,8 @@ var getDataFromFFMpeg = function(filepath, options, callback){
 				duration *= 60;
 				duration += val;
 			}
+			duration = duration + (parseInt(strList[3]) / 100);
+
 
 			var channels = matches2[2];
 


### PR DESCRIPTION
Currently the duration parsing from the ffmpeg string throws out the fraction of a second to get the duration. This causes the number of samples to be calculated incorrectly later on.

I added a line to the duration parsing to add the fraction.